### PR TITLE
Fix deployment base path configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "path=/$REPO_NAME/pr${{ github.event.pull_request.number }}/" >> $GITHUB_OUTPUT
+            echo "path=/$REPO_NAME/pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "dir=pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
-            echo "path=/$REPO_NAME/" >> $GITHUB_OUTPUT
+            echo "path=/$REPO_NAME" >> $GITHUB_OUTPUT
             echo "dir=." >> $GITHUB_OUTPUT
           fi
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -283,3 +283,27 @@
     - Implement local game setup (shuffle and deal).
     - Establish the 70s Groovy aesthetic via CSS variables.
 - Delegating the implementation to `@coder`.
+
+## 2026-05-06: Fix Deployment Failure (Base Path Configuration)
+
+**User Prompt:**
+> Run the pages deploy workflow and observe:
+> ```
+> nix develop --command bun run build
+> warning: Git tree '/home/runner/work/gotfive/gotfive' is dirty
+> $ vite build
+> error during build:
+> [Could not load /home/runner/work/gotfive/gotfive/svelte.config.js: config.kit.paths.base option must either be the empty string or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths
+> ]
+> error: script "build" exited with code 1
+> Error: Process completed with exit code 1.
+> ```
+> fix it so that the game deploys.
+
+**Action Plan (Orchestration):**
+- Identified root cause: `PUBLIC_BASE_PATH` in CI contains a trailing slash, which SvelteKit's `paths.base` forbids.
+- Formulated a robust fix:
+    - Update `svelte.config.js` and `vite.config.ts` to automatically strip trailing slashes from `PUBLIC_BASE_PATH`.
+    - Update `.github/workflows/deploy.yml` to set `path` without a trailing slash.
+- Verified the fix locally by reproducing the error and then confirming the build succeeds with a trailing-slashed environment variable.
+- Delegating the implementation to `@coder`.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -307,3 +307,10 @@
     - Update `.github/workflows/deploy.yml` to set `path` without a trailing slash.
 - Verified the fix locally by reproducing the error and then confirming the build succeeds with a trailing-slashed environment variable.
 - Delegating the implementation to `@coder`.
+
+## 2026-05-06: Verification and PR Creation (Orchestration)
+
+- Verified the Coder's changes in `svelte.config.js`, `vite.config.ts`, and `.github/workflows/deploy.yml`.
+- Ran a local build with `PUBLIC_BASE_PATH=/gotfive/` and confirmed it succeeds.
+- Created PR #17 to merge the fix into `main`.
+- Moving the task to Human Review.

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,7 +10,7 @@ const config = {
 			fallback: '404.html'
 		}),
 		paths: {
-			base: process.env.PUBLIC_BASE_PATH || '',
+			base: (process.env.PUBLIC_BASE_PATH || '').replace(/\/$/, ''),
 		}
 	}
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig(({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), '');
-	const basePath = env.PUBLIC_BASE_PATH || '';
+	const basePath = (env.PUBLIC_BASE_PATH || '').replace(/\/$/, '');
 
 	return {
 		base: basePath,


### PR DESCRIPTION
Fixes #16. 

This PR addresses the build failure in the deployment workflow caused by trailing slashes in the base path. 
- Modified `svelte.config.js` and `vite.config.ts` to strip trailing slashes from `PUBLIC_BASE_PATH`.
- Updated `.github/workflows/deploy.yml` to provide the base path without a trailing slash.
- Verified that the build succeeds with a trailing-slashed base path.