### PR TITLE
Remove redundant e2e tests from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Install dependencies
         run: nix develop --command bun install
 
-      - name: Install Playwright Browsers
-        run: nix develop --command bunx playwright install --with-deps
-
       - name: Prepare build environment
         id: build_env
         run: |
@@ -52,17 +49,6 @@ jobs:
           PUBLIC_BASE_PATH: ${{ steps.base_path.outputs.path }}
           VITE_APP_VERSION: ${{ steps.build_env.outputs.version }}
           VITE_GIT_HASH: ${{ steps.build_env.outputs.git_hash }}
-
-      - name: Run E2E tests
-        run: nix develop --command bun run test:e2e
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
 
       - name: Deploy to gh-pages branch
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && success())


### PR DESCRIPTION
The deploy workflow needlessly runs the e2e tests. They are already run for each PR and on main, and so deploy can assume the other workflow is responsible for keeping e2e green.

Closes #51