### PR TITLE
Stabilize public lobby E2E state

### DIFF
--- a/tests/e2e/003-multiplayer/003-multiplayer.spec.ts
+++ b/tests/e2e/003-multiplayer/003-multiplayer.spec.ts
@@ -82,12 +82,15 @@ test.describe('Multiplayer Lobby', () => {
 		// 3. Client checks for Public Game
 		await expect(clientPage.getByRole('heading', { name: 'Public Games' })).toBeVisible();
 		const gameCard = clientPage.locator('.game-card').filter({ hasText: "Host's Public Game" });
+		const hostLobbyEntry = clientPage.locator('.players-list li').filter({ hasText: 'Host' });
 		await expect(gameCard).toBeVisible();
+		await expect(hostLobbyEntry).toContainText('playing');
 
 		await tester.step('public-game-visible', {
 			description: 'Public game is visible in the lobby',
 			verifications: [
-				{ spec: 'Game card is visible', check: async () => await expect(gameCard).toBeVisible() }
+				{ spec: 'Game card is visible', check: async () => await expect(gameCard).toBeVisible() },
+				{ spec: 'Host is projected as playing', check: async () => await expect(hostLobbyEntry).toContainText('playing') }
 			]
 		});
 

--- a/tests/e2e/003-multiplayer/README.md
+++ b/tests/e2e/003-multiplayer/README.md
@@ -8,6 +8,7 @@ Testing public game discovery and joining.
 
 **Verifications:**
 - [x] Game card is visible
+- [x] Host is projected as playing
 
 ---
 


### PR DESCRIPTION
## Summary
- fix the main E2E failure in the public game lobby screenshot
- wait for the client lobby projection to include the host as `playing` before taking the screenshot
- update the generated E2E README verification list

## Root cause
The failing screenshot could capture the public game card before the `/users` projection had fully reflected the host presence/activity. CI saw a different stable lobby state than the baseline. The test now waits for the complete intended state instead of only the game card.

## Validation
- Targeted: `firebase emulators:exec --only auth,firestore "playwright test tests/e2e/003-multiplayer/003-multiplayer.spec.ts"` -> 3 passed
- Full: `nix develop --command bun run test:e2e` -> 13 passed
- `bun run check`
- `bun run build`